### PR TITLE
Update to GTK4 and newer GHC versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+dist-newstyle
 cabal-dev
 *.swp
 *.o

--- a/README.markdown
+++ b/README.markdown
@@ -10,30 +10,34 @@ windows, built on top of the diagrams-cairo backend and the gi-gtk package.
 
 ## Prerequisites
 
-You need a GTK3 development installation since gi-gtk and diagrams-cairo are required packages and these need them. See there for further explanations.
+You need a GTK4 development installation since gi-gtk and diagrams-cairo are required packages and these need them. See there for further explanations.
 
 ## Compilation from the repository
 
-To build and install the core library from the source repository, simply type
+To build and install the core library from the source repository, simply type:
+```bash
+cd diagrams-gi-gtk
+cabal build
+```
 
-    cd diagrams-gi-gtk && cabal install && cd ..
+To build the examples, type:
+```bash
+cabal build -fbuildExamples
+```
 
-To build the examples, type
+To run the examples, type:
+```bash
+cabal run ex1 -fbuildExamples
+```
 
-    cd diagrams-gi-gtk
-    cabal configure -fbuildExamples && cabal build
-    cd ..
+## How to use
 
-If you like stack then
-
-    stack build
-
-should do the trick too. In order to include the example in the build use
-
-    stack build --flag diagrams-gi-gtk:buildExamples
-
-instead.
-
+Given that `diagram :: Diagram Cairo` and `drawingArea :: DrawingArea` are in scope, the following snippet
+shows how to render the diagram within the drawing area:
+```haskell
+Gtk.drawingAreaSetDrawFunc drawingArea $ Just $ \_ context width height ->
+    defaultRender True diagram context width height
+```
 # License
 
 The source code is distributed under a MIT license. See the `LICENSE` file.

--- a/diagrams-gi-gtk.cabal
+++ b/diagrams-gi-gtk.cabal
@@ -1,5 +1,6 @@
+cabal-version:       3.0
 name:                diagrams-gi-gtk
-version:             0.1
+version:             0.2
 synopsis:            Backend for rendering diagrams directly to GTK windows based on gi-gtk package
 description:         An optional add-on to the diagrams-cairo package
                      which allows rendering diagrams directly to GTK DrawingArea widgets
@@ -12,8 +13,7 @@ maintainer:          tkx68@icloud.com
 copyright:           2019 Torsten Kemps-Benedix
 category:            Graphics
 build-type:          Simple
-cabal-version:       >=1.10
-tested-with:         GHC == 8.4.4
+tested-with:         GHC == 9.2.2
 extra-source-files:  README.markdown
 
 source-repository head
@@ -26,35 +26,34 @@ flag buildExamples
 
 library
   exposed-modules:     Diagrams.Backend.GIGtk
-  build-depends:       base >= 4.2 && < 4.12,
-                       transformers >= 0.5 && < 0.6,
-                       diagrams-lib >= 1.3 && < 1.5,
-                       diagrams-cairo >= 1.3 && < 1.5,
-                       cairo >= 0.13 && < 0.14,
-                       gi-gdk >= 3.0 && < 3.1,
-                       gi-gtk >= 3.0 && < 3.1,
-                       gi-cairo >= 1.0 && < 1.1
+  build-depends:       base >= 4.13,
+                       transformers >= 0.5,
+                       diagrams-lib >= 1.4,
+                       diagrams-cairo >= 1.4,
+                       cairo >= 0.13,
+                       gi-gdk >= 4,
+                       gi-gtk >= 4,
+                       gi-cairo >= 1.0
   hs-source-dirs:      src
   default-language:    Haskell2010
 
 executable ex1
   if flag(buildExamples)
-    build-depends:     base >= 4.2 && < 4.12,
-                       text >= 1.2 && <= 1.3,
-                       transformers >= 0.5 && < 0.6,
-                       diagrams >= 1.4 && < 1.5,
-                       diagrams-lib >= 1.4 && < 1.5,
-                       diagrams-cairo >= 1.3 && < 1.5,
+    build-depends:     base >= 4.13,
+                       text >= 1.2,
+                       transformers >= 0.5,
+                       diagrams >= 1.4,
+                       diagrams-lib >= 1.4,
+                       diagrams-cairo >= 1.4,
                        diagrams-gi-gtk,
-                       cairo >= 0.13 && < 0.14,
-                       gi-gtk >= 3.0 && < 3.1,
-                       gi-gdk >= 3.0 && < 3.1,
-                       haskell-gi >= 0.21,
-                       colour >= 2.3 && < 2.4,
-                       haskell-gi-base >= 0.21,
+                       gi-gtk >= 4,
+                       gi-gdk >= 4,
+                       haskell-gi >= 0.25,
+                       colour >= 2.3,
+                       haskell-gi-base >= 0.25,
                        gi-glib >= 2.0,
-                       vector-space >= 0.16 && < 0.17,
-                       gi-cairo >= 1.0 && < 1.1
+                       vector-space >= 0.16,
+                       gi-cairo >= 1.0
   else
     buildable: False
   hs-source-dirs:      examples

--- a/examples/diagrams-gi-gtk-example1.hs
+++ b/examples/diagrams-gi-gtk-example1.hs
@@ -1,41 +1,43 @@
-{- | A first example of drawing diagrams from within GTK.  This
-     program draws a Koch snowflake with the depth controllable
-     via a GTK widget.
--}
-{-# LANGUAGE OverloadedLabels, OverloadedStrings, TypeFamilies, FlexibleContexts, NoMonomorphismRestriction #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | A first example of drawing diagrams from within GTK.  This
+--     program draws a Koch snowflake with the depth controllable
+--     via a GTK widget.
 module Main where
 
-import Control.Monad
-import qualified GI.Gdk as Gdk
-import qualified GI.Gtk as Gtk
-import Data.GI.Base
-import Diagrams.Prelude hiding (set)
-import Diagrams.Size (requiredScaling)
-import Diagrams.Backend.GIGtk
-import Diagrams.Backend.Cairo (Cairo)
 import qualified Data.Colour as C
+import Diagrams.Backend.Cairo (Cairo)
+import Diagrams.Backend.GIGtk ( defaultRender )
+import Diagrams.Prelude
+import GI.Gtk (AttrOp (..))
+import qualified GI.Gtk as Gtk
 
 -- The classic Hilbert curves from the diagrams gallery:
 hilbert :: Int -> Diagram Cairo
-hilbert = frame 1 . lw medium . lc (colors!!1) . strokeT . hilbert'
+hilbert = frame 1 . lw medium . lc (colors !! 1) . strokeT . hilbert'
   where
     hilbert' :: Int -> Trail V2 Double
     hilbert' 0 = mempty
     hilbert' n =
-        hilbert'' (n-1) # reflectY <> vrule 1
-        <> hilbert'  (n-1) <> hrule 1
-        <> hilbert'  (n-1) <> vrule (-1)
-        <> hilbert'' (n-1) # reflectX
+      hilbert'' (n - 1) # reflectY <> vrule 1
+        <> hilbert' (n - 1)
+        <> hrule 1
+        <> hilbert' (n - 1)
+        <> vrule (-1)
+        <> hilbert'' (n - 1) # reflectX
       where
         hilbert'' :: Int -> Trail V2 Double
-        hilbert'' m = hilbert' m # rotateBy (1/4)
+        hilbert'' m = hilbert' m # rotateBy (1 / 4)
 
 -- Some more drawing code, copied from
 -- projects.haskell.org/diagrams/gallery/Pentaflake.html
-colors ::[Colour Double]
+colors :: [Colour Double]
 colors = iterate (C.blend 0.1 white) red
 
-p ::Diagram Cairo
+p :: Diagram Cairo
 p = regPoly 5 1 # lwO 0
 
 -- | create a snowflake diagram of depth @n@
@@ -44,90 +46,72 @@ p = regPoly 5 1 # lwO 0
 -- for @drawToGtk@, otherwise get a "No instance for (PathLike ..." error.
 pentaflake :: Int -> Diagram Cairo
 pentaflake 0 = p
-pentaflake n = appends (p' # fc (colors !! (n-1)))
-                       (zip vs (repeat (rotateBy (1/2) p')))
-  where vs = take 5 . iterate (rotateBy (1/5))
-                    . (if odd n then negated else id) $ unitY
-        p' = pentaflake (n-1)
+pentaflake n =
+  appends
+    (p' # fc (colors !! (n - 1)))
+    (zip vs (repeat (rotateBy (1 / 2) p')))
+  where
+    vs =
+      take 5 . iterate (rotateBy (1 / 5))
+        . (if odd n then negated else id)
+        $ unitY
+    p' = pentaflake (n - 1)
 
-pentaflake' ::Int -> Diagram Cairo
+pentaflake' :: Int -> Diagram Cairo
 pentaflake' n = pentaflake n # fc (colors !! n)
 
--- A function to set up the main window and signal handlers
-createMainWindow :: IO Gtk.Window
-createMainWindow = do
-    win <- new Gtk.Window []
+-- Set up the application window and add the diagrams
+activate :: Gtk.Application -> IO ()
+activate app = do
+  win <- Gtk.new Gtk.ApplicationWindow [#application := app, #title := "Diagrams GI-GTK Example"]
 
-    on win #keyPressEvent $ \event -> do
-        name <- event `get` #keyval >>= Gdk.keyvalName
-        when (name == Just "Escape") Gtk.mainQuit
-        return False
+  depthWidget <- Gtk.spinButtonNewWithRange 1 10 1
+  -- when the spinButton changes, redraw the window
+  Gtk.on depthWidget #valueChanged $ do
+    Gtk.widgetQueueDraw win -- drawArea
+    return ()
 
-    depthWidget <- Gtk.spinButtonNewWithRange 1 10 1
-    -- when the spinButton changes, redraw the window
-    on depthWidget #valueChanged $ do
-        Gtk.widgetQueueDraw win --drawArea
-        return ()
+  rbHilbert <- Gtk.new Gtk.CheckButton [#label := "Hilbert", #active := True]
+  rbPentaFlake <- Gtk.new Gtk.CheckButton [#label := "Penta Flake", #active := False, #group := rbHilbert]
+  radioButtons <- Gtk.new Gtk.Box [#orientation := Gtk.OrientationVertical]
 
-    rbHilbert <- Gtk.radioButtonNewWithLabelFromWidget Gtk.noRadioButton "Hilbert"
-    set rbHilbert [#active := True]
-    rbPentaFlake <- Gtk.radioButtonNewWithLabelFromWidget (Just rbHilbert) "Penta Flake"
-    set rbPentaFlake [#active := False]
-    boxRB <- Gtk.boxNew Gtk.OrientationVertical 0
-    Gtk.boxPackStart boxRB rbHilbert False False 0
-    Gtk.boxPackStart boxRB rbPentaFlake False False 0
+  #append radioButtons rbHilbert
+  #append radioButtons rbPentaFlake
 
-    drawArea <- new Gtk.DrawingArea [#widthRequest := 512, #heightRequest := 512]
+  drawArea <- Gtk.new Gtk.DrawingArea [#widthRequest := 512, #heightRequest := 512]
 
-    -- add the depthWidget control and drawArea to the main window
-    hbox <- Gtk.boxNew Gtk.OrientationVertical 0
-    Gtk.boxPackStart hbox boxRB False False 0 -- box child expand fill extraPadding
-    Gtk.boxPackStart hbox depthWidget False False 0 -- box child expand fill extraPadding
-    Gtk.boxPackStart hbox drawArea True True 0
-    #add win hbox
+  hbox <- Gtk.new Gtk.Box [#orientation := Gtk.OrientationVertical]
 
-    on rbHilbert #toggled $ do
-        Gtk.widgetQueueDraw drawArea
---        hilbertActive <- get rbHilbert #active
---        putStrLn $ "Hilbert curve is: "++(show hilbertActive)
-        return ()
---
---    on rbPentaFlake #toggled $ do
---        pentaFlakeActive <- get rbPentaFlake #active
---        putStrLn $ "Penta flake is: "++(show pentaFlakeActive)
---        return ()
---
-    -- handle the drawArea's @onExpose@ signal.  We provide a function
-    -- that takes an area marked as dirty and redraws it.
-    -- This program simply redraws the entire drawArea.
-    --
-    -- Many gtk signal handlers return True if the signal was handled, and False
-    -- otherwise (in which case the signal will be propagated to the parent).
-    on drawArea #draw $ \context -> do
-        rect <- Gtk.widgetGetAllocation drawArea  -- size in pixels (Int)
-        canvasX <- get rect #width
-        canvasY <- get rect #height
-        curDepth <- fromIntegral <$> Gtk.spinButtonGetValueAsInt depthWidget
-        hilbertActive <- get rbHilbert #active
-        let dia = if hilbertActive then hilbert curDepth else pentaflake curDepth
-            w = width dia
-            h = height dia
-            spec = mkSizeSpec2D (Just $ fromIntegral canvasX) (Just $ fromIntegral canvasY)
-            scaledDia = toGtkCoords $ transform (requiredScaling spec (V2 w h)) dia
-        renderToGtk context True scaledDia
-        return True
+  #append hbox radioButtons
+  #append hbox depthWidget
+  #append hbox drawArea
 
-    return win
+  Gtk.windowSetChild win (Just hbox)
+
+  -- Redraw on changes to input parameters of the diagram
+  Gtk.on rbHilbert #toggled $ Gtk.widgetQueueDraw drawArea
+  Gtk.on depthWidget #changed $ Gtk.widgetQueueDraw drawArea
+
+  Gtk.drawingAreaSetDrawFunc drawArea $
+    Just $ \_ context width height -> do
+      curDepth <- fromIntegral <$> Gtk.spinButtonGetValueAsInt depthWidget
+      hilbertActive <- Gtk.get rbHilbert #active
+      let diagram = if hilbertActive then hilbert curDepth else pentaflake curDepth
+      defaultRender True diagram context width height
+
+  #show win
 
 -- Gtk application
 --
--- Initialize the library, create and show the main window,
--- finally enter the main loop
+-- Start the GTK application
 main :: IO ()
 main = do
-    Gtk.init Nothing
-    win <- createMainWindow
-    on win #destroy Gtk.mainQuit
-    Gtk.widgetShowAll win
-    Gtk.main
+  app <-
+    Gtk.new
+      Gtk.Application
+      [ #applicationId Gtk.:= "Diagrams GI-GTK Example",
+        Gtk.On #activate (activate ?self)
+      ]
 
+  #run app Nothing
+  pure ()

--- a/src/Diagrams/Backend/GIGtk.hs
+++ b/src/Diagrams/Backend/GIGtk.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE CPP #-}
+
 -----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+
 -- |
 -- Module      :  Diagrams.Backend.Gtk
 -- Copyright   :  (c) 2019 Torsten Kemps-Benedix
@@ -20,41 +24,46 @@
 -- for the original GTK3 documentation.
 --
 -- @
--- {-# LANGUAGE OverloadedLabels, OverloadedStrings, TypeFamilies, FlexibleContexts, NoMonomorphismRestriction #-}
+-- {-# LANGUAGE ImplicitParams #-}
+-- {-# LANGUAGE OverloadedLabels #-}
+-- {-# LANGUAGE OverloadedStrings #-}
+-- {-# LANGUAGE TypeFamilies #-}
+--
+-- -- | A first example of drawing diagrams from within GTK.  This
+-- --     program draws a Koch snowflake with the depth controllable
+-- --     via a GTK widget.
 -- module Main where
 --
--- import Control.Monad
--- import qualified GI.Gdk as Gdk
--- import qualified GI.Gtk as Gtk
--- import Data.GI.Base
--- import Diagrams.Prelude hiding (set)
--- import Diagrams.Size (requiredScaling)
--- import Diagrams.Backend.GIGtk
--- import Diagrams.Backend.Cairo (Cairo)
 -- import qualified Data.Colour as C
--- import Data.Text (Text)
--- import qualified Data.Text as T
+-- import Diagrams.Backend.Cairo (Cairo)
+-- import Diagrams.Backend.GIGtk ( defaultRender )
+-- import Diagrams.Prelude
+-- import GI.Gtk (AttrOp (..))
+-- import GI.Gtk qualified as Gtk
 --
+-- -- The classic Hilbert curves from the diagrams gallery:
 -- hilbert :: Int -> Diagram Cairo
--- hilbert = frame 1 . lw medium . lc (colors!!1) . strokeT . hilbert'
+-- hilbert = frame 1 . lw medium . lc (colors !! 1) . strokeT . hilbert'
 --   where
 --     hilbert' :: Int -> Trail V2 Double
 --     hilbert' 0 = mempty
 --     hilbert' n =
---         hilbert'' (n-1) # reflectY <> vrule 1
---         <> hilbert'  (n-1) <> hrule 1
---         <> hilbert'  (n-1) <> vrule (-1)
---         <> hilbert'' (n-1) # reflectX
+--       hilbert'' (n - 1) # reflectY <> vrule 1
+--         <> hilbert' (n - 1)
+--         <> hrule 1
+--         <> hilbert' (n - 1)
+--         <> vrule (-1)
+--         <> hilbert'' (n - 1) # reflectX
 --       where
 --         hilbert'' :: Int -> Trail V2 Double
---         hilbert'' m = hilbert' m # rotateBy (1/4)
+--         hilbert'' m = hilbert' m # rotateBy (1 / 4)
 --
--- -- Our drawing code, copied from
+-- -- Some more drawing code, copied from
 -- -- projects.haskell.org/diagrams/gallery/Pentaflake.html
--- colors ::[Colour Double]
+-- colors :: [Colour Double]
 -- colors = iterate (C.blend 0.1 white) red
 --
--- p ::Diagram Cairo
+-- p :: Diagram Cairo
 -- p = regPoly 5 1 # lwO 0
 --
 -- -- | create a snowflake diagram of depth @n@
@@ -63,105 +72,94 @@
 -- -- for @drawToGtk@, otherwise get a "No instance for (PathLike ..." error.
 -- pentaflake :: Int -> Diagram Cairo
 -- pentaflake 0 = p
--- pentaflake n = appends (p' # fc (colors !! (n-1)))
---                        (zip vs (repeat (rotateBy (1/2) p')))
---   where vs = take 5 . iterate (rotateBy (1/5))
---                     . (if odd n then negated else id) $ unitY
---         p' = pentaflake (n-1)
+-- pentaflake n =
+--   appends
+--     (p' # fc (colors !! (n - 1)))
+--     (zip vs (repeat (rotateBy (1 / 2) p')))
+--   where
+--     vs =
+--       take 5 . iterate (rotateBy (1 / 5))
+--         . (if odd n then negated else id)
+--         $ unitY
+--     p' = pentaflake (n - 1)
 --
--- pentaflake' ::Int -> Diagram Cairo
+-- pentaflake' :: Int -> Diagram Cairo
 -- pentaflake' n = pentaflake n # fc (colors !! n)
 --
--- -- end of diagrams code
+-- -- Set up the application window and add the diagrams
+-- activate :: Gtk.Application -> IO ()
+-- activate app = do
+--   win <- Gtk.new Gtk.ApplicationWindow [#application := app, #title := "Diagrams GI-GTK Example"]
 --
--- -- A function to set up the main window and signal handlers
--- createMainWindow :: IO Gtk.Window
--- createMainWindow = do
---     win <- new Gtk.Window []
+--   depthWidget <- Gtk.spinButtonNewWithRange 1 10 1
+--   -- when the spinButton changes, redraw the window
+--   Gtk.on depthWidget #valueChanged $ do
+--     Gtk.widgetQueueDraw win -- drawArea
+--     return ()
 --
---     on win #keyPressEvent $ \event -> do
---         name <- event `get` #keyval >>= Gdk.keyvalName
---         when (name == Just "Escape") Gtk.mainQuit
---         return False
+--   rbHilbert <- Gtk.new Gtk.CheckButton [#label := "Hilbert", #active := True]
+--   rbPentaFlake <- Gtk.new Gtk.CheckButton [#label := "Penta Flake", #active := False, #group := rbHilbert]
+--   radioButtons <- Gtk.new Gtk.Box [#orientation := Gtk.OrientationVertical]
 --
---     depthWidget <- Gtk.spinButtonNewWithRange 1 10 1
---     -- when the spinButton changes, redraw the window
---     on depthWidget #valueChanged $ do
---         Gtk.widgetQueueDraw win --drawArea
---         return ()
+--   #append radioButtons rbHilbert
+--   #append radioButtons rbPentaFlake
 --
---     rbHilbert <- Gtk.radioButtonNewWithLabelFromWidget Gtk.noRadioButton "Hilbert"
---     set rbHilbert [#active := True]
---     rbPentaFlake <- Gtk.radioButtonNewWithLabelFromWidget (Just rbHilbert) "Penta Flake"
---     set rbPentaFlake [#active := False]
---     boxRB <- Gtk.boxNew Gtk.OrientationVertical 0
---     Gtk.boxPackStart boxRB rbHilbert False False 0
---     Gtk.boxPackStart boxRB rbPentaFlake False False 0
+--   drawArea <- Gtk.new Gtk.DrawingArea [#widthRequest := 512, #heightRequest := 512]
 --
---     drawArea <- new Gtk.DrawingArea [#widthRequest := 512, #heightRequest := 512]
+--   hbox <- Gtk.new Gtk.Box [#orientation := Gtk.OrientationVertical]
 --
---     -- add the depthWidget control and drawArea to the main window
---     hbox <- Gtk.boxNew Gtk.OrientationVertical 0
---     Gtk.boxPackStart hbox boxRB False False 0 -- box child expand fill extraPadding
---     Gtk.boxPackStart hbox depthWidget False False 0 -- box child expand fill extraPadding
---     Gtk.boxPackStart hbox drawArea True True 0
---     #add win hbox
+--   #append hbox radioButtons
+--   #append hbox depthWidget
+--   #append hbox drawArea
 --
---     on rbHilbert #toggled $ do
---         Gtk.widgetQueueDraw drawArea
---         return ()
+--   Gtk.windowSetChild win (Just hbox)
 --
---     -- handle the drawArea's @onExpose@ signal.  We provide a function
---     -- that takes an area marked as dirty and redraws it.
---     -- This program simply redraws the entire drawArea.
---     --
---     -- Many gtk signal handlers return True if the signal was handled, and False
---     -- otherwise (in which case the signal will be propagated to the parent).
---     on drawArea #draw $ \context -> do
---         rect <- Gtk.widgetGetAllocation drawArea  -- size in pixels (Int)
---         canvasX <- get rect #width
---         canvasY <- get rect #height
---         curDepth <- fromIntegral <$> Gtk.spinButtonGetValueAsInt depthWidget
---         hilbertActive <- get rbHilbert #active
---         let dia = if hilbertActive then hilbert curDepth else pentaflake curDepth
---             w = width dia
---             h = height dia
---             spec = mkSizeSpec2D (Just $ fromIntegral canvasX) (Just $ fromIntegral canvasY)
---             scaledDia = toGtkCoords $ transform (requiredScaling spec (V2 w h)) dia
---         renderToGtk context scaledDia
---         return True
+--   -- Redraw on changes to input parameters of the diagram
+--   Gtk.on rbHilbert #toggled $ Gtk.widgetQueueDraw drawArea
+--   Gtk.on depthWidget #changed $ Gtk.widgetQueueDraw drawArea
 --
---     return win
+--   Gtk.drawingAreaSetDrawFunc drawArea $
+--     Just $ \_ context width height -> do
+--       curDepth <- fromIntegral <$> Gtk.spinButtonGetValueAsInt depthWidget
+--       hilbertActive <- Gtk.get rbHilbert #active
+--       let diagram = if hilbertActive then hilbert curDepth else pentaflake curDepth
+--       defaultRender True diagram context width height
+--
+--   #show win
 --
 -- -- Gtk application
 -- --
--- -- Initialize the library, create and show the main window,
--- -- finally enter the main loop
+-- -- Start the GTK application
 -- main :: IO ()
 -- main = do
---     Gtk.init Nothing
---     win <- createMainWindow
---     on win #destroy Gtk.mainQuit
---     Gtk.widgetShowAll win
---     Gtk.main
+--   app <-
+--     Gtk.new
+--       Gtk.Application
+--       [ #applicationId Gtk.:= "Diagrams GI-GTK Example",
+--         Gtk.On #activate (activate ?self)
+--       ]
+--
+--   #run app Nothing
+--   pure ()
+--
 -- @
------------------------------------------------------------------------------
 module Diagrams.Backend.GIGtk
-       ( defaultRender
-       , toGtkCoords
-       , renderToGtk
-       ) where
+  ( defaultRender,
+    toGtkCoords,
+    renderToGtk,
+  )
+where
 
-import           Control.Monad.Trans.Reader (runReaderT)
-import           Diagrams.Prelude hiding (render, height, width)
-import           Diagrams.Backend.Cairo.Internal
-import           Foreign.Ptr (castPtr)
-import           GHC.Int
-import qualified GI.Cairo (Context(..))
-import           GI.Gtk
+import Control.Monad.Trans.Reader (runReaderT)
+import Diagrams.Backend.Cairo.Internal
+import Diagrams.Prelude hiding (height, render, width)
+import Foreign.Ptr (castPtr)
+import GHC.Int (Int32)
+import qualified GI.Cairo (Context (..))
+import GI.Gtk (withManagedPtr)
 import qualified Graphics.Rendering.Cairo as Cairo
-import qualified Graphics.Rendering.Cairo.Internal as Cairo (Render(runRender))
-import qualified Graphics.Rendering.Cairo.Types as Cairo (Cairo(Cairo))
+import qualified Graphics.Rendering.Cairo.Internal as Cairo (Render (runRender))
+import qualified Graphics.Rendering.Cairo.Types as Cairo (Cairo (Cairo))
 
 -- | This function bridges gi-cairo with the hand-written cairo
 -- package. It takes a `GI.Cairo.Context` (as it appears in gi-cairo),
@@ -169,7 +167,7 @@ import qualified Graphics.Rendering.Cairo.Types as Cairo (Cairo(Cairo))
 -- `Render` action into the given context.
 renderWithContext :: GI.Cairo.Context -> Cairo.Render () -> IO ()
 renderWithContext ct r = withManagedPtr ct $ \p ->
-                         runReaderT (Cairo.runRender r) (Cairo.Cairo (castPtr p))
+  runReaderT (Cairo.runRender r) (Cairo.Cairo (castPtr p))
 
 -- | Convert a Diagram to the backend coordinates.
 --
@@ -185,28 +183,38 @@ renderWithContext ct r = withManagedPtr ct $ \p ->
 -- `toGtkCoords` does no rescaling of the diagram, however it is centered in
 -- the window.
 toGtkCoords :: Monoid' m => QDiagram Cairo V2 Double m -> QDiagram Cairo V2 Double m
-toGtkCoords d = (\(_,_,d') -> d') $
-  adjustDia Cairo
-            (CairoOptions "" absolute RenderOnly False)
-            d
+toGtkCoords d =
+  (\(_, _, d') -> d') $
+    adjustDia
+      Cairo
+      (CairoOptions "" absolute RenderOnly False)
+      d
 
--- | Render a diagram to a 'DrawingArea''s context with double buffering,
+-- | Render a diagram to a 'DrawingArea''s context with double buffering if needed,
 --   rescaling to fit the full area.
 defaultRender ::
-     Monoid' m =>
-    GI.Cairo.Context -- ^ DrawingArea's context to render onto --  provided by the draw event
-    -> Bool -- ^render double buffered?
-    -> QDiagram Cairo V2 Double m   -- ^ Diagram
-    -> IO ()
-defaultRender ctx diagram = do
-  render ctx opts diagram
-    where opts w h = (CairoOptions
-              { _cairoFileName     = ""
-              , _cairoSizeSpec     = dims (V2 (fromIntegral w) (fromIntegral h))
-              , _cairoOutputType   = RenderOnly
-              , _cairoBypassAdjust = False
-              }
-           )
+  Monoid' m =>
+  -- | render double buffered?
+  Bool ->
+  -- | Diagram
+  QDiagram Cairo V2 Double m ->
+  -- | DrawingArea's context to render onto
+  GI.Cairo.Context ->
+  -- | Width
+  Int32 ->
+  -- | Height
+  Int32 ->
+  IO ()
+defaultRender db diagram ctx w h = render db opts diagram ctx
+  where
+    opts =
+      ( CairoOptions
+          { _cairoFileName = "",
+            _cairoSizeSpec = dims (V2 (fromIntegral w) (fromIntegral h)),
+            _cairoOutputType = RenderOnly,
+            _cairoBypassAdjust = False
+          }
+      )
 
 -- | Render a diagram to a 'DrawArea''s context with double buffering.  No
 --   rescaling or transformations will be performed.
@@ -214,52 +222,64 @@ defaultRender ctx diagram = do
 --   Typically the diagram will already have been transformed by
 --   'toGtkCoords'.
 renderToGtk ::
-  (Monoid' m)
-  => GI.Cairo.Context -- ^ DrawingArea's context to render onto --  provided by the draw event
-  -> Bool -- ^render double buffered?
-  -> QDiagram Cairo V2 Double m  -- ^ Diagram
-  -> IO ()
-renderToGtk ctx db = render ctx opts db
-  where opts _ _ = (CairoOptions
-                    { _cairoFileName     = ""
-                    , _cairoSizeSpec     = absolute
-                    , _cairoOutputType   = RenderOnly
-                    , _cairoBypassAdjust = True
-                    }
-                   )
+  (Monoid' m) =>
+  -- | Render double-buffered
+  Bool ->
+  -- | Diagram
+  QDiagram Cairo V2 Double m ->
+  -- | DrawingArea's context to render onto --  provided by the draw event
+  GI.Cairo.Context ->
+  -- | Width
+  Int32 ->
+  -- | Height
+  Int32 ->
+  IO ()
+renderToGtk db diagram ctx w h = render db opts diagram ctx
+  where
+    opts =
+      ( CairoOptions
+          { _cairoFileName = "",
+            _cairoSizeSpec = absolute,
+            _cairoOutputType = RenderOnly,
+            _cairoBypassAdjust = True
+          }
+      )
 
 -- | Render a diagram onto a 'GI.Cairo.Context' using the given CairoOptions. Place this within a 'draw' event callback which provides the DrawArea's context.
 --
---   This uses cairo double-buffering.
+--   This uses cairo double-buffering if the thirs parameter is set to True..
 render ::
   (Monoid' m) =>
-  GI.Cairo.Context -- ^ DrawingArea's 'GI.Cairo.Context' to render the digram onto
-  -> (Int32 -> Int32 -> Options Cairo V2 Double) -- ^ options, depending on drawable width and height
-  -> Bool -- ^render double buffered?
-  -> QDiagram Cairo V2 Double m -- ^ Diagram
-  -> IO ()
-render ctx renderOpts db diagram =
-    renderWithContext ctx (do
-        (x1, x2, y1, y2) <- Cairo.clipExtents
-        let w = round $ x2 - x1
-            h = round $ y2 - y1
-            opts = renderOpts w h
+  -- | DrawingArea's 'GI.Cairo.Context' to render the digram onto
+  Bool ->
+  Options Cairo V2 Double ->
+  QDiagram Cairo V2 Double m ->
+  GI.Cairo.Context ->
+  -- | render double buffered?
+  -- | options, depending on drawable width and height
+  -- | Diagram
+  IO ()
+render db renderOpts diagram ctx =
+  renderWithContext
+    ctx
+    ( do
+        a@(x1, x2, y1, y2) <- Cairo.clipExtents
+        let w = x2 - x1
+            h = y2 - y1
         if db
-            then doubleBuffer $ do
-                delete w h
-                snd (renderDia Cairo opts diagram)
-            else
-                snd (renderDia Cairo opts diagram)
+          then doubleBuffer $ do
+            delete w h
+            snd (renderDia Cairo renderOpts diagram)
+          else snd (renderDia Cairo renderOpts diagram)
     )
 
 --
 --   Used to clear canvas when using double buffering.
-delete :: Int32 -> Int32 -> Cairo.Render ()
+delete :: Double -> Double -> Cairo.Render ()
 delete w h = do
   Cairo.setSourceRGB 1 1 1
-  Cairo.rectangle 0 0 (fromIntegral w) (fromIntegral h)
+  Cairo.rectangle 0 0 (w) (h)
   Cairo.fill
-
 
 -- | Wrap the given render action in double buffering.
 doubleBuffer :: Cairo.Render () -> Cairo.Render ()
@@ -268,4 +288,3 @@ doubleBuffer renderAction = do
   renderAction
   Cairo.popGroupToSource
   Cairo.paint
-

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,5 @@
-resolver: lts-12.26
+resolver: lts-19.15
 packages:
 - .
-extra-deps: [gi-cairo-connector-0.0.1,
-             gi-cairo-render-0.0.1,
-             cairo-0.13.6.0]
+extra-deps: [cairo-0.13.8.2]
 allow-newer: true


### PR DESCRIPTION
I have updated the rendering functions as well as the example to GTK 4.

List of changes:
- Updated Diagrams.Backend.GIGtk so that width/height are also passed to the diagram rendering function, since width/height are parameters of the GTK4 draw callback. 
- Updated the example to use the new GTK4 widgets and main loop.
- Updated version bounds in the cabal file but I am not sure if every allowed configuration would work.
- Updated stack.yaml but I cannot test it since I do not have stack installed.
- Updated Readme.md to include the standard usage example.